### PR TITLE
GITLAB-209: Pin Greenlet library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ raven==6.8.0
 nose==1.3.7
 flask-prom==0.1.1
 ddtrace==0.32.2
+greenlet==0.4.15


### PR DESCRIPTION
We had this issue before: 
![image](https://user-images.githubusercontent.com/5619921/96599740-38258000-12be-11eb-802d-6448ae4752d8.png)


To solution is same as https://github.com/AdaSupport/ficanex-proxy/pull/64/files